### PR TITLE
Replace references to process.EventEmitter with events

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -21,7 +21,7 @@ var fs = require('fs')
   , MemoryStore = require('./stores/memory')
   , SocketNamespace = require('./namespace')
   , Static = require('./static')
-  , EventEmitter = process.EventEmitter;
+  , EventEmitter = require('events');
 
 /**
  * Export the constructor.

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -3,7 +3,7 @@
  */
 
 var Socket = require('./socket')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , parser = require('./parser')
   , util = require('./util');
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -11,7 +11,7 @@
 
 var parser = require('./parser')
   , util = require('./util')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events');
 
 /**
  * Export the constructor.

--- a/lib/store.js
+++ b/lib/store.js
@@ -15,7 +15,7 @@ exports = module.exports = Store;
  * Module dependencies.
  */
 
-var EventEmitter = process.EventEmitter;
+var EventEmitter = require('events');
 
 /**
  * Store interface

--- a/lib/transports/websocket/default.js
+++ b/lib/transports/websocket/default.js
@@ -9,7 +9,7 @@
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , parser = require('../../parser');
 

--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -10,7 +10,7 @@
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , url = require('url')
   , parser = require('../../parser')

--- a/lib/transports/websocket/hybi-16.js
+++ b/lib/transports/websocket/hybi-16.js
@@ -9,7 +9,7 @@
  */
 
 var Transport = require('../../transport')
-  , EventEmitter = process.EventEmitter
+  , EventEmitter = require('events')
   , crypto = require('crypto')
   , url = require('url')
   , parser = require('../../parser')


### PR DESCRIPTION
### GOAL

Replace all references to `process.EventEmitter` with `require('events')`, which is required by node v8+.

This is a maintenance change that already exists in 0.9.18+, but we can't upgrade to 0.9.17 or beyond without some (unexpected?) breaking changes in the API.  So, we'll stay on 0.9.16 until we upgrade the entire stack to the latest and greatest.
