### PR TITLE
Update policyfile version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   , "dependencies": {
         "socket.io-client": "0.9.16"
-      , "policyfile": "0.0.4"
+      , "policyfile": "0.0.6"
       , "base64id": "0.1.0"
     }
   , "devDependencies": {


### PR DESCRIPTION
### SUMMARY

Update the dependency `policyfile` to 0.0.6, which includes the `process.EventEmitter` fix.