### PR TITLE
Fix 64k boundary check error in framing code for this

### DIFF
--- a/lib/transports/websocket/hybi-07-12.js
+++ b/lib/transports/websocket/hybi-07-12.js
@@ -223,7 +223,7 @@ WebSocket.prototype.frame = function (opcode, str) {
     , dataLength = dataBuffer.length
     , startOffset = 2
     , secondByte = dataLength;
-  if (dataLength > 65536) {
+  if (dataLength >= 65536) {
     startOffset = 10;
     secondByte = 127;
   }

--- a/lib/transports/websocket/hybi-16.js
+++ b/lib/transports/websocket/hybi-16.js
@@ -222,7 +222,7 @@ WebSocket.prototype.frame = function (opcode, str) {
     , dataLength = dataBuffer.length
     , startOffset = 2
     , secondByte = dataLength;
-  if (dataLength > 65536) {
+  if (dataLength >= 65536) {
     startOffset = 10;
     secondByte = 127;
   }


### PR DESCRIPTION
socket.io built-in implementation of websocket.

For contextual details, see [this bug comment](https://jira.dp.hbo.com/browse/GA-49514?focusedCommentId=740666&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-740666).  Quoted:

> OK. Root cause fixed (well - not the root cause that our socket.io can't be updated).  All finished. Short story: https://github.com/HBOCodeLabs/socket.io/pull/3 has a PR to fix the root cause; which will need to be followed by a change to Hadron's package.json to pick up the fix. (Note: We already pickup this package from our own HBO fork of the repo.)
Longer story - which seems like an hour or two of work, but was a bit more:
Eventually repro'd and determined that packets right 'at' 64k we're broken.  Above or below were fine.
With more debugging determined that the frame being received had a 2-byte length header, but the length was set to 0.  More debugging the realize the packet in question was not actually 0xFFFF in length, but was intended to be 0x10000 in length.
Pulled up RFC-6455 on WebSockets to better understand the framing specification and if there was some weird case where 0-length packets were not allowed and were special cased to be max_size+1.   Nope. In fact 5.2 and 5.7 make it especially clear that something sent the wrong framing.
OK.  After digging through Chrome's native implementation, nothing looked like it could be wrong.  On a while, ran the repro-under safari and it still crashed.
Eventually I realized/remembered that the client does not talk directly to the automation server, but instead has it's data proxied through atlas.
Atlas, I realized uses the package 'socket.io', where as I'd been debugging socket.io-client in the automation client without thinking about it.
Setting breakpoints in node.js's WebSockets no longer worked when debugging Atlas.  Setting higher level breakpoints and stepping down, I realized what other probably have always known.  Our socket.io package used by Atlas has it's own embedded implementation of WebSockets (Specifically socket.io/lib/transports/websocket/hybi-16.j).
Well hell.  At this point I was familiar enough with the framing spec to know exactly what I was looking for, and sure enough... off by 1 in the embedded implementation.  So for whatever reason we have our own fork of socket.io in the HBO CodeLabs repo.  I think to update security package dependencies on our long unsupported release.   I've made the fix in that repo as I believe it's the best tactical choice.  Strategically we need to update socket.io and friends to something modern.  We really need to update this crap.
